### PR TITLE
Allow for DirectUpload configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+
+* Allows host to be configured, since some apps host their front-end on a different server than their API. Thanks, @derigible
+
+## [0.0.3] — 2018-02-12
+
 ### Changed
 
 * Exports flow types so you can import them
@@ -23,5 +29,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 * A component that handles the direct upload of a file to an ActiveStorage service and calls render props with arguments that let you build your own upload widget.
 
-[unreleased]: https://github.com/cbothner/react-activestorage-provider/compare/v0.0.2...HEAD
+[unreleased]: https://github.com/cbothner/react-activestorage-provider/compare/v0.0.3...HEAD
+[0.0.3]: https://github.com/cbothner/react-activestorage-provider/compare/v0.0.2...0.0.3
 [0.0.2]: https://github.com/cbothner/react-activestorage-provider/compare/v0.0.1...v0.0.2

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ These are your options for configuring ActiveStorageProvider.
 
 | Prop (\*required)        | Description                                                                                                                |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `endpoint`\*             | `{ path: string, model: string, attribute: string, method: string, host: string, port: string, protocol: string }`<br />The details for the request to attach the file   |
+| `endpoint`\*             | `{ path: string, model: string, attribute: string, method: string }`<br />The details for the request to attach the file   |
 | `multiple`               | `boolean`<br/>Whether the component should accept multiple files. If true, the model should use `has_many_attached`.       |
 | `onBeforeBlobRequest`    | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the blob request    |
 | `onBeforeStorageRequest` | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the storage request |

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ These are your options for configuring ActiveStorageProvider.
 
 | Prop (\*required)        | Description                                                                                                                |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `endpoint`\*             | `{ path: string, model: string, attribute: string, method: string }`<br />The details for the request to attach the file   |
+| `endpoint`\*             | `{ path: string, model: string, attribute: string, method: string, host: string, port: string, protocol: string }`<br />The details for the request to attach the file   |
 | `multiple`               | `boolean`<br/>Whether the component should accept multiple files. If true, the model should use `has_many_attached`.       |
 | `onBeforeBlobRequest`    | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the blob request    |
 | `onBeforeStorageRequest` | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the storage request |

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ npm install --save react-activestorage-provider
 
 These are your options for configuring ActiveStorageProvider.
 
-| Prop (\*required)        | Description                                                                                                                |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `endpoint`\*             | `{ path: string, model: string, attribute: string, method: string, host: string, port: string, protocol: string }`<br />The details for the request to attach the file   |
-| `multiple`               | `boolean`<br/>Whether the component should accept multiple files. If true, the model should use `has_many_attached`.       |
-| `onBeforeBlobRequest`    | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the blob request    |
-| `onBeforeStorageRequest` | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the storage request |
-| `onSubmit`\*             | `Object => mixed`<br />A callback for the server response to the upload                                                    |
-| `render`\*               | `RenderProps => React.Node`<br />Render props                                                                              |
+| Prop (\*required)        | Description                                                                                                                                                                |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `endpoint`\*             | `{ path: string, model: string, attribute: string, method: string, host?: string, port?: string, protocol?: string }`<br />The details for the request to attach the file. |
+| `multiple`               | `boolean`<br/>Whether the component should accept multiple files. If true, the model should use `has_many_attached`.                                                       |
+| `onBeforeBlobRequest`    | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the blob request                                                    |
+| `onBeforeStorageRequest` | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the storage request                                                 |
+| `onSubmit`\*             | `Object => mixed`<br />A callback for the server response to the upload                                                                                                    |
+| `render`\*               | `RenderProps => React.Node`<br />Render props                                                                                                                              |
 
 ### `RenderProps`
 

--- a/src/VirtualForm.js
+++ b/src/VirtualForm.js
@@ -58,10 +58,20 @@ class VirtualForm {
   _createFileInput() {
     this._input = document.createElement('input')
     this._input.type = 'file'
-    this._input.dataset.directUploadUrl = CONVENTIONAL_DIRECT_UPLOADS_PATH
+    this._input.dataset.directUploadUrl = this._directUploadsUrl()
     this._input.name = this._inputName()
     this._input.multiple = Boolean(this.props.multiple)
     return this._input
+  }
+
+  _directUploadsUrl() {
+    const { host, protocol, port } = this.props.endpoint
+    if(host) {
+      const builtProtocol = protocol ? `${protocol.split(':')[0]}://` : 'https://'
+      const builtPort = port ? `:${port}` : ''
+      return `${builtProtocol}${host}${builtPort}${CONVENTIONAL_DIRECT_UPLOADS_PATH}`
+    }
+    return CONVENTIONAL_DIRECT_UPLOADS_PATH
   }
 
   _createSubmitButton() {

--- a/src/VirtualForm.js
+++ b/src/VirtualForm.js
@@ -58,16 +58,18 @@ class VirtualForm {
   _createFileInput() {
     this._input = document.createElement('input')
     this._input.type = 'file'
-    this._input.dataset.directUploadUrl = this._createUploadsPath()
+    this._input.dataset.directUploadUrl = this._directUploadsUrl()
     this._input.name = this._inputName()
     this._input.multiple = Boolean(this.props.multiple)
     return this._input
   }
 
-  _createUploadsPath() {
+  _directUploadsUrl() {
     const { host, protocol, port } = this.props.endpoint
-    if(host) {
-      const builtProtocol = protocol ? `${protocol.split(':')[0]}://` : 'https://'
+    if (host) {
+      const builtProtocol = protocol
+        ? `${protocol.split(':')[0]}://`
+        : 'https://'
       const builtPort = port ? `:${port}` : ''
       return `${builtProtocol}${host}${builtPort}${CONVENTIONAL_DIRECT_UPLOADS_PATH}`
     }

--- a/src/VirtualForm.js
+++ b/src/VirtualForm.js
@@ -58,13 +58,13 @@ class VirtualForm {
   _createFileInput() {
     this._input = document.createElement('input')
     this._input.type = 'file'
-    this._input.dataset.directUploadUrl = this._directUploadsUrl()
+    this._input.dataset.directUploadUrl = this._createUploadsPath()
     this._input.name = this._inputName()
     this._input.multiple = Boolean(this.props.multiple)
     return this._input
   }
 
-  _directUploadsUrl() {
+  _createUploadsPath() {
     const { host, protocol, port } = this.props.endpoint
     if(host) {
       const builtProtocol = protocol ? `${protocol.split(':')[0]}://` : 'https://'

--- a/src/types.js
+++ b/src/types.js
@@ -13,6 +13,9 @@ export type Endpoint = {
   model: string,
   attribute: string,
   method: string,
+  host?: string,
+  port?: string,
+  protocol?: string,
 }
 
 export type RenderProps = {


### PR DESCRIPTION
Some apps do not host their front end assets
under the same domain as the api. This allows
for clients to point the upload at the
correct server.