### PR TITLE
Expose lower level DirectUploadProvider component

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,5 +9,6 @@
 [options]
 module.use_strict=true
 suppress_type=$FlowIssue
+unsafe.enable_getters_and_setters=true
 
 [strict]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,54 +6,58 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+
+- Exposes a lower level component `DirectUploadProvider` that creates a `Blob` record and uploads the file, then returns the attachment IDs for the consumer to attach.
+
 ## [0.4.0] — 2018-10-12
 
 ### Added
 
-* Accepts an `onError` callback prop. If saving the model returns an error status code, such as from failed validations, we need to be able to alert the user.
+- Accepts an `onError` callback prop. If saving the model returns an error status code, such as from failed validations, we need to be able to alert the user.
 
 ## [0.3.0] — 2018-08-06
 
 ### Added
 
-* Added a `token` prop so that a JWT for the Authorization header can be passed. Thanks, @MikeKotte
+- Added a `token` prop so that a JWT for the Authorization header can be passed. Thanks, @MikeKotte
 
 ## [0.2.0] — 2018-06-26
 
 ### Changed
 
-* `handleUpload` now takes `File[]` or `FileList` for greater flexibility.
+- `handleUpload` now takes `File[]` or `FileList` for greater flexibility.
 
 ## [0.1.1] — 2018-04-30
 
 ### Fixed
 
-* Correctly send multiple blob ids for multiple attachments.
+- Correctly send multiple blob ids for multiple attachments.
 
 ## [0.1.0] — 2018-04-27
 
 ### Added
 
-* Allows host to be configured, since some apps host their front-end on a different server than their API. Thanks, @derigible
+- Allows host to be configured, since some apps host their front-end on a different server than their API. Thanks, @derigible
 
 ## [0.0.3] — 2018-02-12
 
 ### Changed
 
-* Exports flow types so you can import them
+- Exports flow types so you can import them
 
 ## [0.0.2] — 2018-02-09
 
 ### Changed
 
-* Parses the server response as JSON automatically and calls `onSubmit` with the contents of the response body
-* Uses `Accept: 'application/json'` so you don’t need to end `endpoint.path` with `.json`
+- Parses the server response as JSON automatically and calls `onSubmit` with the contents of the response body
+- Uses `Accept: 'application/json'` so you don’t need to end `endpoint.path` with `.json`
 
 ## 0.0.1 — 2018-02-09
 
 ### Added
 
-* A component that handles the direct upload of a file to an ActiveStorage service and calls render props with arguments that let you build your own upload widget.
+- A component that handles the direct upload of a file to an ActiveStorage service and calls render props with arguments that let you build your own upload widget.
 
 [unreleased]: https://github.com/cbothner/react-activestorage-provider/compare/v0.4.0...HEAD
 [0.4.0]: https://github.com/cbothner/react-activestorage-provider/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ActiveStorage is an amazing addition to Rails 5.2, and as usual the team have made it fantastically simple to use... if you’re generating HTML server-side, that is. This component aims to make it just as easy to use from React.
 
-ActiveStorageProvider handles the direct upload of a file to an ActiveStorage service and calls render props with arguments that let you build your own upload widget.
+ActiveStorageProvider handles the direct upload of a file to an ActiveStorage service and the attachment of that file to your model. It uses the render props pattern so you can build your own upload widget.
 
 ## Install
 
@@ -13,6 +13,8 @@ npm install --save react-activestorage-provider
 ```
 
 ## Usage
+
+ActiveStorageProvider makes it easy to add a simple upload button. When you call `handleUpload` with a `FileList` or an array of `File`s, this component creates a `Blob` record, uploads the file directly to your storage service, and then hits your Rails controller to attach the blob to your model. (If you want to handle the attachment yourself, [see below](#directuploadprovider).)
 
 ```jsx
 <ActiveStorageProvider
@@ -31,22 +33,26 @@ npm install --save react-activestorage-provider
         onChange={e => handleUpload(e.currentTarget.files)}
       />
 
-      {uploads.map(
-        upload =>
-          upload.state === 'waiting' ? (
-            <p key={upload.id}>Waiting to upload {upload.file.name}</p>
-          ) : upload.state === 'uploading' ? (
-            <p key={upload.id}>
-              Uploading {upload.file.name}: {upload.progress}%
-            </p>
-          ) : upload.state === 'error' ? (
-            <p key={upload.id}>
-              Error uploading {upload.file.name}: {upload.error}
-            </p>
-          ) : (
-            <p key={upload.id}>Finished uploading {upload.file.name}</p>
-          )
-      )}
+      {uploads.map(upload => {
+        switch (upload.state) {
+          case 'waiting':
+            return <p key={upload.id}>Waiting to upload {upload.file.name}</p>
+          case 'uploading':
+            return (
+              <p key={upload.id}>
+                Uploading {upload.file.name}: {upload.progress}%
+              </p>
+            )
+          case 'error':
+            return (
+              <p key={upload.id}>
+                Error uploading {upload.file.name}: {upload.error}
+              </p>
+            )
+          case 'finished':
+            return <p key={upload.id}>Finished uploading {upload.file.name}</p>
+        }
+      })}
     </div>
   )}
 />
@@ -56,16 +62,16 @@ npm install --save react-activestorage-provider
 
 These are your options for configuring ActiveStorageProvider.
 
-| Prop (\*required)        | Description                                                                                                                                                                |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `endpoint`\*             | `{ path: string, model: string, attribute: string, method: string, host?: string, port?: string, protocol?: string }`<br />The details for the request to attach the file. |
-| `multiple`               | `boolean`<br/>Whether the component should accept multiple files. If true, the model should use `has_many_attached`.                                                       |
-| `token`                  | `string`<br/>Optional authorization token.                                                                                                                                 |
-| `onBeforeBlobRequest`    | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the blob request                                                    |
-| `onBeforeStorageRequest` | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the storage request                                                 |
-| `onSubmit`\*             | `Object => mixed`<br />A callback for the server response to successfully saving your model                                                                                |
-| `onError`                | `Response => mixed`<br />A callback to handle an error (>= 400) response by the server in saving your model                                                                |
-| `render`\*               | `RenderProps => React.Node`<br />Render props                                                                                                                              |
+| Prop (\*required)        | Description                                                                                                                                                               |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `endpoint`\*             | `{ path: string, model: string, attribute: string, method: string, host?: string, port?: string, protocol?: string }`<br />The details for the request to attach the file |
+| `multiple`               | `boolean`<br/>Whether the component should accept multiple files. If true, the model should use `has_many_attached`                                                       |
+| `onBeforeBlobRequest`    | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the blob request                                                   |
+| `onBeforeStorageRequest` | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the storage request                                                |
+| `onError`                | `Response => mixed`<br />A callback to handle an error (>= 400) response by the server in saving your model                                                               |
+| `onSubmit`\*             | `Object => mixed`<br />A callback for the server response to successfully saving your model                                                                               |
+| `render`\*               | `RenderProps => React.Node`<br />Render props                                                                                                                             |
+| `token`                  | `string`<br/>Optional authorization token                                                                                                                                 |
 
 ### `RenderProps`
 
@@ -73,7 +79,7 @@ This is the type of the argument with which your render function will be called.
 
 ```jsx
 type RenderProps = {
-  handleUpload: (FileList | File[]) => void /* call to initiate an upload */,
+  handleUpload: (FileList | File[]) => mixed /* call to initiate an upload */,
   ready: boolean /* false while any file is uploading */,
   uploads: ActiveStorageFileUpload[] /* uploads in progress */,
 }
@@ -84,3 +90,17 @@ type ActiveStorageFileUpload =
   | { state: 'error', id: string, file: File, error: string }
   | { state: 'finished', id: string, file: File }
 ```
+
+## `DirectUploadProvider`
+
+ActiveStorageProvider makes it simple to add a quick “upload” button by taking care of both uploading and attaching your file, but it shouldn’t stand in your way if you’re doing something more interesting. If you want to handle the second step, attaching your `Blob` record to your model, yourself, you can use the lower level `DirectUploadProvider`. It creates the blob records and uploads the user’s files directly to your storage service, then calls you back with the signed ids of those blobs.
+
+| Prop (\*required)        | Description                                                                                                                             |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `directUploadsPath`      | `string`<br />The direct uploads path on your Rails app, if you’ve overridden `ActiveStorage::DirectUploadsController`                  |
+| `multiple`               | `boolean`<br/>Whether the component should accept multiple files. If true, the model should use `has_many_attached`                     |
+| `onBeforeBlobRequest`    | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the blob request                 |
+| `onBeforeStorageRequest` | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the storage request              |
+| `onSuccess`\*            | `(string[]) => mixed`<br />The callback that will be called with the signed ids of the files after the upload is complete               |
+| `origin`                 | `{ host?: string, port?: string, protocol?: string }`<br />The origin of your rails server. Defaults to where your React app is running |
+| `render`\*               | `RenderProps => React.Node`<br />Render props                                                                                           |

--- a/src/DirectUploadProvider.js
+++ b/src/DirectUploadProvider.js
@@ -1,0 +1,98 @@
+/**
+ * A component that creates an ActiveStorage::Blob in the Rails database,
+ * uploads the files directly to the storage service and calls a render function
+ * prop to allow the consumer to display the upload’s progress. On completion,
+ * it calls back with the signed ids of the created blob objects.
+ *
+ * @providesModule DirectUploadProvider
+ * @flow
+ */
+
+import * as React from 'react'
+
+import Upload from './Upload'
+
+import type { ActiveStorageFileUpload, Origin, RenderProps } from './types'
+
+export type DelegatedProps = {|
+  multiple?: boolean,
+  onBeforeBlobRequest?: ({
+    id: string,
+    file: File,
+    xhr: XMLHttpRequest,
+  }) => mixed,
+  onBeforeStorageRequest?: ({
+    id: string,
+    file: File,
+    xhr: XMLHttpRequest,
+  }) => mixed,
+  render: RenderProps => React.Node,
+|}
+
+type Props = {
+  ...DelegatedProps,
+  origin: Origin,
+  directUploadsPath?: string,
+  onSuccess: (string[]) => mixed,
+}
+
+type State = {|
+  uploading: boolean,
+  files: { [string]: ActiveStorageFileUpload },
+|}
+
+class DirectUploadProvider extends React.Component<Props, State> {
+  static defaultProps = {
+    origin: {},
+  }
+
+  state = {
+    uploading: false,
+    files: {},
+  }
+
+  render() {
+    const { files } = this.state
+    return this.props.render({
+      handleUpload: this.handleChooseFiles,
+      ready: !this.state.uploading,
+      uploads: Object.keys(files).map(key => files[key]),
+    })
+  }
+
+  handleChooseFiles = async (files: FileList | File[]) => {
+    if (this.state.uploading) return
+    if (files.length === 0) return
+
+    this.setState({ uploading: true })
+
+    const signedIds = await Promise.all(
+      [...files].map(file => this._upload(file))
+    )
+
+    await this.props.onSuccess(signedIds)
+    this.setState({ files: {}, uploading: false })
+  }
+
+  handleChangeFile = (fileUpload: { [string]: ActiveStorageFileUpload }) =>
+    this.setState(({ files }) => ({ files: { ...files, ...fileUpload } }))
+
+  _upload(file: File): Promise<string> {
+    const {
+      origin,
+      directUploadsPath,
+      onBeforeBlobRequest,
+      onBeforeStorageRequest,
+    } = this.props
+
+    return new Upload(file, {
+      origin,
+      directUploadsPath,
+      onBeforeBlobRequest,
+      onBeforeStorageRequest,
+      onChangeFile: this.handleChangeFile,
+    }).start()
+  }
+}
+
+export default DirectUploadProvider

--- a/src/DirectUploadProvider.test.js
+++ b/src/DirectUploadProvider.test.js
@@ -1,0 +1,65 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import DirectUploadProvider from './DirectUploadProvider'
+
+import type { ReactTestRenderer } from 'react-test-renderer'
+
+global.fetch = require('jest-fetch-mock')
+
+jest.mock('Upload', () =>
+  jest.fn((file, { onChangeFile }) => ({
+    start: jest.fn(() => {
+      onChangeFile({ [file.name]: { fileName: file.name } })
+      return Promise.resolve('signedId')
+    }),
+  }))
+)
+
+import Upload from './Upload'
+
+const onSuccess = jest.fn()
+
+const file = new File([], 'file')
+
+function renderComponent(props: Object = {}): ReactTestRenderer {
+  return renderer.create(
+    <DirectUploadProvider
+      origin={{}}
+      onSuccess={onSuccess}
+      render={props => <div {...props} />}
+      {...props}
+    />
+  )
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  fetch.resetMocks()
+})
+
+describe('DirectUploadProvider', () => {
+  let component, tree
+
+  beforeEach(() => {
+    component = renderComponent()
+    tree = component.toJSON()
+  })
+
+  it('updates the UI with upload progress', () => {
+    expect(tree).toMatchSnapshot()
+
+    tree.props.handleUpload([file])
+    tree = component.toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+
+  it('creates and starts an upload', () => {
+    tree.props.handleUpload([file])
+    expect(Upload).toHaveBeenCalledWith(file, expect.any(Object))
+  })
+
+  it('calls onSuccess prop when uploads are finished', async () => {
+    await tree.props.handleUpload([file])
+    expect(onSuccess).toHaveBeenCalledWith(['signedId'])
+  })
+})

--- a/src/Upload.test.js
+++ b/src/Upload.test.js
@@ -14,7 +14,7 @@ jest.mock('activestorage', () => {
 
 const file = new File([], 'file')
 const options = {
-  endpoint: {},
+  origin: {},
   onChangeFile: jest.fn(),
   onBeforeBlobRequest: jest.fn(),
   onBeforeStorageRequest: jest.fn(),
@@ -53,8 +53,8 @@ describe('Upload', () => {
     `(
       'allows the consumer to specify a different origin { protocol: $protocol, host: $host, port: $port}',
       ({ protocol, host, port, url }) => {
-        const endpoint = { protocol, host, port }
-        const upload = new Upload(file, { ...options, endpoint })
+        const origin = { protocol, host, port }
+        const upload = new Upload(file, { ...options, origin })
         expect(upload.directUploadsUrl).toEqual(url)
       }
     )

--- a/src/__snapshots__/DirectUploadProvider.test.js.snap
+++ b/src/__snapshots__/DirectUploadProvider.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DirectUploadProvider updates the UI with upload progress 1`] = `
+<div
+  handleUpload={[Function]}
+  ready={true}
+  uploads={Array []}
+/>
+`;
+
+exports[`DirectUploadProvider updates the UI with upload progress 2`] = `
+<div
+  handleUpload={[Function]}
+  ready={false}
+  uploads={
+    Array [
+      Object {
+        "fileName": "file",
+      },
+    ]
+  }
+/>
+`;

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -1,23 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ActiveStorageProvider updates the UI with upload progress 1`] = `
+exports[`ActiveStorageProvider renders a DirectUploadProvider 1`] = `
 <div
-  handleUpload={[Function]}
-  ready={true}
-  uploads={Array []}
-/>
-`;
-
-exports[`ActiveStorageProvider updates the UI with upload progress 2`] = `
-<div
-  handleUpload={[Function]}
-  ready={false}
-  uploads={
-    Array [
-      Object {
-        "fileName": "file",
-      },
-    ]
+  data-component="DirectUploadProvider"
+  onSuccess={[Function]}
+  origin={
+    Object {
+      "host": undefined,
+      "port": undefined,
+      "protocol": undefined,
+    }
   }
+  render={[Function]}
 />
 `;

--- a/src/types.js
+++ b/src/types.js
@@ -8,14 +8,14 @@ export type ActiveStorageFileUpload =
   | { state: 'error', id: string, file: File, error: string }
   | { state: 'finished', id: string, file: File }
 
+export type Origin = { host?: string, port?: string, protocol?: string }
+
 export type Endpoint = {
+  ...Origin,
   path: string,
   model: string,
   attribute: string,
   method: string,
-  host?: string,
-  port?: string,
-  protocol?: string,
 }
 
 export type RenderProps = {


### PR DESCRIPTION
Uploading the file and attaching it to the Rails model are separate things and sometimes you don’t want them to happen together. If you want to handle the second step yourself, you can use the lower level `DirectUploadProvider`. It creates the blob records and uploads the user’s files directly to your storage service, then calls you back with the signed ids of those blobs.

`ActiveStorageProvider` now delegates upload to `DirectUploadProvider` and does only the attachment itself.