### PR TITLE
Provide separate callbacks for choose and upload as an option

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -9,6 +9,5 @@
 [options]
 module.use_strict=true
 suppress_type=$FlowIssue
-unsafe.enable_getters_and_setters=true
 
 [strict]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ### Added
 
-- Exposes a lower level component `DirectUploadProvider` that creates a `Blob` record and uploads the file, then returns the attachment IDs for the consumer to attach.
+- Exposed a lower level component `DirectUploadProvider` that creates a `Blob` record and uploads the file, then returns the attachment IDs for the consumer to attach.
+- Allows choosing files and beginning their upload to be two separate processes by adding two more callbacks to RenderProps.
 
 ## [0.4.0] — 2018-10-12
 

--- a/README.md
+++ b/README.md
@@ -78,10 +78,18 @@ These are your options for configuring ActiveStorageProvider.
 This is the type of the argument with which your render function will be called.
 
 ```jsx
-type RenderProps = {
-  handleUpload: (FileList | File[]) => mixed /* call to initiate an upload */,
+export type RenderProps = {
   ready: boolean /* false while any file is uploading */,
   uploads: ActiveStorageFileUpload[] /* uploads in progress */,
+
+  handleUpload: (FileList | File[]) => mixed /* call to initiate an upload */,
+
+  /* or, if you want more granular control... */
+
+  /* call to set list of files to be uploaded */
+  handleChooseFiles: (FileList | File[]) => mixed,
+  /* then call to begin the upload of the files in the list */
+  handleBeginUpload: () => mixed,
 }
 
 type ActiveStorageFileUpload =

--- a/src/__snapshots__/DirectUploadProvider.test.js.snap
+++ b/src/__snapshots__/DirectUploadProvider.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`DirectUploadProvider updates the UI with upload progress 1`] = `
 <div
+  handleBeginUpload={[Function]}
+  handleChooseFiles={[Function]}
   handleUpload={[Function]}
   ready={true}
   uploads={Array []}
@@ -10,6 +12,8 @@ exports[`DirectUploadProvider updates the UI with upload progress 1`] = `
 
 exports[`DirectUploadProvider updates the UI with upload progress 2`] = `
 <div
+  handleBeginUpload={[Function]}
+  handleChooseFiles={[Function]}
   handleUpload={[Function]}
   ready={false}
   uploads={

--- a/src/types.js
+++ b/src/types.js
@@ -19,7 +19,15 @@ export type Endpoint = {
 }
 
 export type RenderProps = {
-  handleUpload: (FileList | File[]) => mixed /* call to initiate an upload */,
   ready: boolean /* false while any file is uploading */,
   uploads: ActiveStorageFileUpload[] /* uploads in progress */,
+
+  handleUpload: (FileList | File[]) => mixed /* call to initiate an upload */,
+
+  /* or, if you want more granular control... */
+
+  /* call to set list of files to be uploaded */
+  handleChooseFiles: (FileList | File[]) => mixed,
+  /* begin the upload of the files in the list */
+  handleBeginUpload: () => mixed,
 }


### PR DESCRIPTION
In order to allow choosing files and beginning their upload to be two
separate processes, this adds `handleChooseFiles` and
`handleBeginUpload` to RenderProps.

Co-Authored-By: Pearl Zeng <zhuzeng@umich.edu>