### PR TITLE
Remove redundant token prop in favor of headers 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 - If `X-CSRF-Token` is included in the `headers` prop, we are no longer fetching the CSRF token from the meta tags.
 
+### Removed
+- Removed the special-case `token` prop in favor of the more general `headers` prop, to which you can pass the Authorization header. You can replace `token="Bearer asdf"` with `headers={{ Authorization: 'Bearer asdf' }}`
+
 ## [0.5.0] — 2018-10-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ These are your options for configuring ActiveStorageProvider.
 | `onError`                | `Response => mixed`<br />A callback to handle an error (>= 400) response by the server in saving your model                                                               |
 | `onSubmit`\*             | `Object => mixed`<br />A callback for the server response to successfully saving your model                                                                               |
 | `render`\*               | `RenderProps => React.Node`<br />Render props                                                                                                                             |
-| `token`                  | `string`<br/>Optional authorization token                                                                                                                                 |
 | `headers`                | `{[key: string]: string}`<br/>Optional headers to add to request                                                                                                          |
 
 ### `RenderProps`

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,6 @@ export type { ActiveStorageFileUpload, Endpoint, RenderProps } from './types'
 type Props = {|
   ...DelegatedProps,
   endpoint: Endpoint,
-  token?: string,
   onSubmit: Object => mixed,
   onError?: Response => mixed,
   headers?: CustomHeaders,
@@ -34,7 +33,6 @@ class ActiveStorageProvider extends React.Component<Props> {
   render() {
     const {
       endpoint: { host, port, protocol },
-      token,
       onSubmit,
       headers,
       ...props
@@ -61,7 +59,7 @@ class ActiveStorageProvider extends React.Component<Props> {
   }
 
   async _hitEndpointWithSignedIds(signedIds: string[]): Promise<Object> {
-    const { endpoint, multiple, token, headers } = this.props
+    const { endpoint, multiple, headers } = this.props
     const { path, method, attribute, model } = endpoint
     const body = {
       [model.toLowerCase()]: {
@@ -77,7 +75,6 @@ class ActiveStorageProvider extends React.Component<Props> {
       headers: new Headers({
         Accept: 'application/json',
         'Content-Type': 'application/json',
-        ...(token ? { Authorization: token } : {}),
         ...(addCSRFHeader ? csrfHeader() : {}),
         ...headers,
       }),


### PR DESCRIPTION
Adding props for all the different headers users may want to include with the result is unsustainably, and #9 is a better, more general solution.

Replacing `token="Bearer asdf"` with `headers={{ Authorization: 'Bearer asdf' }}` is also clearer.
