### PR TITLE
Support using ActiveStorageProvider component with a customized direct uploads controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Changed
 
 - ActiveStorageProvider now passes custom headers down to the DirectUploadProvider it uses. This change is to better support users who customize their DirectUploadsController, in response to [this conversation](https://github.com/cbothner/react-activestorage-provider/issues/22).
+- ActiveStorageProvider accepts the `directUploadsPath` so users who have customized their DirectUploadsController don’t need to use DirectUploadProvider directly.
 
 ## [0.7.0] — 2019-01-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Changed
+
+- ActiveStorageProvider now passes custom headers down to the DirectUploadProvider it uses. This change is to better support users who customize their DirectUploadsController, in response to [this conversation](https://github.com/cbothner/react-activestorage-provider/issues/22).
+
 ## [0.7.0] — 2019-01-03
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,45 +24,49 @@ import ActiveStorageProvider from 'react-activestorage-provider'
 
 // ...
 
-<ActiveStorageProvider
-  endpoint={{
-    path: '/profile',
-    model: 'User',
-    attribute: 'avatar',
-    method: 'PUT',
-  }}
-  onSubmit={user => this.setState({ avatar: user.avatar })}
-  render={({ handleUpload, uploads, ready }) => (
-    <div>
-      <input
-        type="file"
-        disabled={!ready}
-        onChange={e => handleUpload(e.currentTarget.files)}
-      />
+return (
+  <ActiveStorageProvider
+    endpoint={{
+      path: '/profile',
+      model: 'User',
+      attribute: 'avatar',
+      method: 'PUT',
+    }}
+    onSubmit={user => this.setState({ avatar: user.avatar })}
+    render={({ handleUpload, uploads, ready }) => (
+      <div>
+        <input
+          type="file"
+          disabled={!ready}
+          onChange={e => handleUpload(e.currentTarget.files)}
+        />
 
-      {uploads.map(upload => {
-        switch (upload.state) {
-          case 'waiting':
-            return <p key={upload.id}>Waiting to upload {upload.file.name}</p>
-          case 'uploading':
-            return (
-              <p key={upload.id}>
-                Uploading {upload.file.name}: {upload.progress}%
-              </p>
-            )
-          case 'error':
-            return (
-              <p key={upload.id}>
-                Error uploading {upload.file.name}: {upload.error}
-              </p>
-            )
-          case 'finished':
-            return <p key={upload.id}>Finished uploading {upload.file.name}</p>
-        }
-      })}
-    </div>
-  )}
-/>
+        {uploads.map(upload => {
+          switch (upload.state) {
+            case 'waiting':
+              return <p key={upload.id}>Waiting to upload {upload.file.name}</p>
+            case 'uploading':
+              return (
+                <p key={upload.id}>
+                  Uploading {upload.file.name}: {upload.progress}%
+                </p>
+              )
+            case 'error':
+              return (
+                <p key={upload.id}>
+                  Error uploading {upload.file.name}: {upload.error}
+                </p>
+              )
+            case 'finished':
+              return (
+                <p key={upload.id}>Finished uploading {upload.file.name}</p>
+              )
+          }
+        })}
+      </div>
+    )}
+  />
+)
 ```
 
 ### `ActiveStorageProvider` Props
@@ -71,14 +75,15 @@ These are your options for configuring ActiveStorageProvider.
 
 | Prop (\*required)        | Description                                                                                                                                                               |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `directUploadsPath`      | `string`<br />The direct uploads path on your Rails app, if you’ve overridden `ActiveStorage::DirectUploadsController`                                                    |
 | `endpoint`\*             | `{ path: string, model: string, attribute: string, method: string, host?: string, port?: string, protocol?: string }`<br />The details for the request to attach the file |
+| `headers`                | `{[key: string]: string}`<br/>Optional headers to add to request, can also be used to override default headers                                                            |
 | `multiple`               | `boolean` (false)<br/>Whether the component should accept multiple files. If true, the model should use `has_many_attached`                                               |
 | `onBeforeBlobRequest`    | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the blob request                                                   |
 | `onBeforeStorageRequest` | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the storage request                                                |
 | `onError`                | `Response => mixed`<br />A callback to handle an error (>= 400) response by the server in saving your model                                                               |
 | `onSubmit`\*             | `Object => mixed`<br />A callback for the server response to successfully saving your model                                                                               |
 | `render`\*               | `RenderProps => React.Node`<br />Render props                                                                                                                             |
-| `headers`                | `{[key: string]: string}`<br/>Optional headers to add to request, can also be used to override default headers                                                            |
 
 ### `RenderProps`
 
@@ -111,18 +116,20 @@ type ActiveStorageFileUpload =
 ActiveStorageProvider makes it simple to add a quick “upload” button by taking care of both uploading and attaching your file, but it shouldn’t stand in your way if you’re doing something more interesting. If you want to handle the second step, attaching your `Blob` record to your model, yourself, you can use the lower level `DirectUploadProvider`. It creates the blob records and uploads the user’s files directly to your storage service, then calls you back with the signed ids of those blobs.
 
 `DirectUploadProvider` is a named export, so
+
 ```jsx
 import { DirectUploadProvider } from 'react-activestorage-provider'
 ```
+
 and use it with the following props:
 
 | Prop (\*required)        | Description                                                                                                                             |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `directUploadsPath`      | `string`<br />The direct uploads path on your Rails app, if you’ve overridden `ActiveStorage::DirectUploadsController`                  |
+| `headers`                | `{[key: string]: string}`<br/>Optional headers to add to request                                                                        |
 | `multiple`               | `boolean`<br/>Whether the component should accept multiple files. If true, the model should use `has_many_attached`                     |
 | `onBeforeBlobRequest`    | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the blob request                 |
 | `onBeforeStorageRequest` | `({ id: string, file: File, xhr: XMLHttpRequest }) => mixed`<br />A callback that allows you to modify the storage request              |
 | `onSuccess`\*            | `(string[]) => mixed`<br />The callback that will be called with the signed ids of the files after the upload is complete               |
 | `origin`                 | `{ host?: string, port?: string, protocol?: string }`<br />The origin of your rails server. Defaults to where your React app is running |
 | `render`\*               | `RenderProps => React.Node`<br />Render props                                                                                           |
-| `headers`                | `{[key: string]: string}`<br/>Optional headers to add to request                                                                        |

--- a/src/DirectUploadProvider.js
+++ b/src/DirectUploadProvider.js
@@ -20,6 +20,7 @@ import type {
 } from './types'
 
 export type DelegatedProps = {|
+  directUploadsPath?: string,
   multiple?: boolean,
   onBeforeBlobRequest?: ({
     id: string,
@@ -37,7 +38,6 @@ export type DelegatedProps = {|
 type Props = {
   ...DelegatedProps,
   origin: Origin,
-  directUploadsPath?: string,
   onSuccess: (string[]) => mixed,
   headers?: CustomHeaders,
 }
@@ -105,20 +105,20 @@ class DirectUploadProvider extends React.Component<Props, State> {
 
   _createUpload(file: File) {
     const {
-      origin,
       directUploadsPath,
+      headers,
       onBeforeBlobRequest,
       onBeforeStorageRequest,
-      headers,
+      origin,
     } = this.props
 
     return new Upload(file, {
-      origin,
       directUploadsPath,
+      headers,
       onBeforeBlobRequest,
       onBeforeStorageRequest,
       onChangeFile: this.handleChangeFileUpload,
-      headers,
+      origin,
     })
   }
 }

--- a/src/DirectUploadProvider.test.js
+++ b/src/DirectUploadProvider.test.js
@@ -25,10 +25,18 @@ const onSuccess = jest.fn()
 
 const file = new File([], 'file')
 
+const uploadOptions = {
+  directUploadsPath: 'direct_uploads',
+  headers: { 'X-Custom': true },
+  onBeforeBlobRequest: jest.fn(),
+  onBeforeStorageRequest: jest.fn(),
+  origin: {},
+}
+
 function renderComponent(props) {
   return renderer.create(
     <DirectUploadProvider
-      origin={{}}
+      {...uploadOptions}
       onSuccess={onSuccess}
       render={props => <div {...props} />}
       {...props}
@@ -59,13 +67,19 @@ describe('DirectUploadProvider', () => {
 
   it('creates and starts an upload when handleUpload is called', () => {
     tree.props.handleUpload([file])
-    expect(Upload).toHaveBeenCalledWith(file, expect.any(Object))
+    expect(Upload).toHaveBeenCalledWith(
+      file,
+      expect.objectContaining(uploadOptions)
+    )
     expect(Upload.mock.results[0].value.start).toHaveBeenCalled()
   })
 
   it('creates an upload when handleChooseFiles is called', () => {
     tree.props.handleChooseFiles([file])
-    expect(Upload).toHaveBeenCalledWith(file, expect.any(Object))
+    expect(Upload).toHaveBeenCalledWith(
+      file,
+      expect.objectContaining(uploadOptions)
+    )
     expect(Upload.mock.results[0].value.start).not.toHaveBeenCalled()
   })
 

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`ActiveStorageProvider renders a DirectUploadProvider 1`] = `
 <div
   data-component="DirectUploadProvider"
+  headers={Object {}}
   onSuccess={[Function]}
   origin={
     Object {

--- a/src/__snapshots__/index.test.js.snap
+++ b/src/__snapshots__/index.test.js.snap
@@ -3,7 +3,16 @@
 exports[`ActiveStorageProvider renders a DirectUploadProvider 1`] = `
 <div
   data-component="DirectUploadProvider"
-  headers={Object {}}
+  directUploadsPath="direct_uploads/"
+  headers={
+    Object {
+      "X-Custom": true,
+    }
+  }
+  multiple={false}
+  onBeforeBlobRequest={[MockFunction]}
+  onBeforeStorageRequest={[MockFunction]}
+  onError={[MockFunction]}
   onSuccess={[Function]}
   origin={
     Object {

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,6 @@ class ActiveStorageProvider extends React.Component<Props> {
     const {
       endpoint: { host, port, protocol },
       onSubmit,
-      headers,
       ...props
     } = this.props
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -28,7 +28,13 @@ const userData = { id: '1', avatar: 'file' }
 function renderComponent(props: Object = {}) {
   return renderer.create(
     <ActiveStorageProvider
+      directUploadsPath="direct_uploads/"
       endpoint={endpoint}
+      headers={{ 'X-Custom': true }}
+      multiple={false}
+      onBeforeBlobRequest={jest.fn()}
+      onBeforeStorageRequest={jest.fn()}
+      onError={jest.fn()}
       onSubmit={onSubmit}
       render={props => <div {...props} />}
       {...props}


### PR DESCRIPTION
`ActiveStorageProvider` provides a simple solution for the most basic setup, and `DirectUploadProvider` is available for more complex needs. But the complex needs we had in mind were situations with interesting UI/UX complexity, not implementation details of whether or not Rails is being used to render the React app.

The conversation in #22 made it clear that `ActiveStorageProvider` could support users who aren’t rendering their single-page apps with Rails by passing along any custom headers to its internal `DirectUploadProvider`. Since there’s no harm in including unnecessary headers, this won’t interfere with full-stack Rails apps.

Additionally, since a custom direct uploads controller may call for a non-default route, `ActiveStorageProvider` will also accept and forward the `directUploadsPath` prop that `DirectUploadProvider` uses.

Closes #22 