### PR TITLE
Transform body Sent to Endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ type Props = {|
   onSubmit: Object => mixed,
   onError?: Response => mixed,
   headers: CustomHeaders,
+  generateBody: (signedIds: string[]) => Object,
 |}
 
 class ActiveStorageProvider extends React.Component<Props> {
@@ -72,13 +73,16 @@ class ActiveStorageProvider extends React.Component<Props> {
   }
 
   async _hitEndpointWithSignedIds(signedIds: string[]): Promise<Object> {
-    const { endpoint, multiple } = this.props
+    const { endpoint, multiple, generateBody } = this.props
     const { path, method, attribute, model } = endpoint
-    const body = {
+
+    let body = {
       [model.toLowerCase()]: {
         [attribute]: multiple ? signedIds : signedIds[0],
       },
     }
+
+    if (generateBody) body = generateBody(signedIds)
 
     const response = await fetch(path, {
       credentials: 'same-origin',

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -74,6 +74,29 @@ describe('ActiveStorageProvider', () => {
     expect(onSubmit).toHaveBeenCalledWith(userData)
   })
 
+  it('transforms the body and hits the given endpoint when generateBody is present', async () => {
+    const customBody = {
+      id: 1,
+      extraField: 'mutation',
+      avatar: 'file',
+    }
+    const generateBodyFn = jest.fn(signedIds => customBody)
+    component = renderComponent({ generateBody: generateBodyFn })
+    tree = component.toJSON()
+    await tree.props.onSuccess(['signedId'])
+
+    expect(generateBodyFn).toHaveBeenCalledWith(['signedId'])
+
+    expect(fetch).toHaveBeenCalledWith(
+      endpoint.path,
+      expect.objectContaining({
+        method: endpoint.method,
+        body: JSON.stringify(customBody),
+      })
+    )
+    expect(onSubmit).toHaveBeenCalledWith(userData)
+  })
+
   it('doesn’t hit the endpoint if handleUpload is called with no files', async () => {
     await tree.props.onSuccess([])
     expect(fetch).not.toHaveBeenCalled()


### PR DESCRIPTION
When creating a new object with an ActiveStorage attachment on it, we often need to send other attributes on the model.

To allow greater flexibility in creating new objects (or perhaps modifying other attributes during a PUT/PATCH) I've added an optional `generateBody` function that will transform the payload sent to the endpoint.

If the function is not present the existing behavior of generating the body is used otherwise the return value of `generateBody` will create the payload.

TODO: update documentation

Resolves #26