### PR TITLE
Default to the same protocol as the page when only given host

### DIFF
--- a/src/Upload.js
+++ b/src/Upload.js
@@ -61,12 +61,12 @@ class Upload {
     } = this.options
 
     if (host) {
-      const builtProtocol = protocol
-        ? `${protocol.split(':')[0]}://`
-        : 'https://'
+      // Given protocol (with consistent punctuation) or same as page by default
+      const builtProtocol = protocol ? `${protocol.split(':')[0]}://` : '//'
       const builtPort = port ? `:${port}` : ''
-      return `${builtProtocol}${host}${builtPort}${directUploadsPath}`
+      return builtProtocol + host + builtPort + directUploadsPath
     }
+
     return directUploadsPath
   }
 

--- a/src/Upload.test.js
+++ b/src/Upload.test.js
@@ -61,8 +61,8 @@ describe('Upload', () => {
       ${'http'}    | ${'0.0.0.0'} | ${3000}      | ${'http://0.0.0.0:3000/rails/active_storage/direct_uploads'}
       ${'http'}    | ${'0.0.0.0'} | ${undefined} | ${'http://0.0.0.0/rails/active_storage/direct_uploads'}
       ${'http://'} | ${'0.0.0.0'} | ${undefined} | ${'http://0.0.0.0/rails/active_storage/direct_uploads'}
-      ${undefined} | ${'0.0.0.0'} | ${3000}      | ${'https://0.0.0.0:3000/rails/active_storage/direct_uploads'}
-      ${undefined} | ${'0.0.0.0'} | ${undefined} | ${'https://0.0.0.0/rails/active_storage/direct_uploads'}
+      ${undefined} | ${'0.0.0.0'} | ${3000}      | ${'//0.0.0.0:3000/rails/active_storage/direct_uploads'}
+      ${undefined} | ${'0.0.0.0'} | ${undefined} | ${'//0.0.0.0/rails/active_storage/direct_uploads'}
     `(
       'allows the consumer to specify a different origin { protocol: $protocol, host: $host, port: $port}',
       ({ protocol, host, port, url }) => {


### PR DESCRIPTION
Per the discussion in #28, it’s not intuitive that the protocol could change
when providing a custom host to the endpoint prop. Instead of defaulting
to `https://`, use `//` as the default prefix for a protocol-relative
url.

Resolves #28