### PR TITLE
Optionally Return Full Response from Direct Uploads Endpoint

### DIFF
--- a/src/DirectUploadProvider.js
+++ b/src/DirectUploadProvider.js
@@ -33,12 +33,13 @@ export type DelegatedProps = {|
     xhr: XMLHttpRequest,
   }) => mixed,
   render: RenderProps => React.Node,
+  fullAttributes?: boolean,
 |}
 
 type Props = {
   ...DelegatedProps,
   origin: Origin,
-  onSuccess: (string[]) => mixed,
+  onSuccess: (any[]) => mixed,
   headers?: CustomHeaders,
 }
 

--- a/src/DirectUploadProvider.js
+++ b/src/DirectUploadProvider.js
@@ -87,11 +87,11 @@ class DirectUploadProvider extends React.Component<Props, State> {
 
     this.setState({ uploading: true })
 
-    const signedIds = await Promise.all(
+    const resultArr = await Promise.all(
       this.uploads.map(upload => upload.start())
     )
 
-    this.props.onSuccess(signedIds)
+    this.props.onSuccess(resultArr)
     this.uploads = []
     this.setState({ fileUploads: {}, uploading: false })
   }
@@ -110,6 +110,7 @@ class DirectUploadProvider extends React.Component<Props, State> {
       onBeforeBlobRequest,
       onBeforeStorageRequest,
       origin,
+      fullAttributes,
     } = this.props
 
     return new Upload(file, {
@@ -119,6 +120,7 @@ class DirectUploadProvider extends React.Component<Props, State> {
       onBeforeStorageRequest,
       onChangeFile: this.handleChangeFileUpload,
       origin,
+      fullAttributes,
     })
   }
 }

--- a/src/Upload.js
+++ b/src/Upload.js
@@ -86,13 +86,13 @@ class Upload {
     })
   }
 
-  handleSuccess = (signedId: string) => {
+  handleSuccess = (result: string | Object) => {
     this.handleChangeFile({
       state: 'finished',
       id: this.id,
       file: this.directUpload.file,
     })
-    return signedId
+    return result
   }
 
   handleError = (error: string) => {
@@ -105,7 +105,7 @@ class Upload {
     throw error
   }
 
-  start(): Promise<string> {
+  start(): Promise<string> | Promise<Object> {
     const promise = new Promise((resolve, reject) => {
       this.directUpload.create((error, attributes) => {
         if (error) reject(error)

--- a/src/Upload.js
+++ b/src/Upload.js
@@ -25,6 +25,7 @@ type Options = {|
   }) => mixed,
   onChangeFile: ({ [string]: ActiveStorageFileUpload }) => mixed,
   headers?: CustomHeaders,
+  fullAttributes?: boolean,
 |}
 
 class Upload {
@@ -108,7 +109,10 @@ class Upload {
     const promise = new Promise((resolve, reject) => {
       this.directUpload.create((error, attributes) => {
         if (error) reject(error)
-        else resolve(attributes.signed_id)
+        else {
+          let result = this.options.fullAttributes ? attributes : attributes.signed_id
+          resolve(result)
+        }
       })
     })
 

--- a/src/Upload.test.js
+++ b/src/Upload.test.js
@@ -10,7 +10,7 @@ jest.mock('activestorage', () => {
       id: 'id',
       file,
       create(cb) {
-        cb(null, { signed_id: 'signedId' })
+        cb(null, { signed_id: 'signedId', key: 'key' })
       },
     })),
   }
@@ -77,6 +77,11 @@ describe('Upload', () => {
     it('resolves with the signed id from the direct upload', async () => {
       const upload = new Upload(file, options)
       expect(await upload.start()).toEqual('signedId')
+    })
+
+    it('resolves with fullAttributes from the direct upload when option "fullAttributes" is true', async () => {
+      const upload = new Upload(file, { ...options, fullAttributes: true })
+      expect(await upload.start()).toEqual({ signed_id: 'signedId', key: 'key' })
     })
 
     it('reports that the upload is finished if it does so', async () => {


### PR DESCRIPTION
### Feature
This PR allows a library user to return the entire response from `/rails/active_storage/direct_uploads` in the `DirectUploaderProvider` `onSuccess` callback when `fullAttributes` flag is set on the `DirectUploadProvider`.

### Example
```
<DirectUploadProvider
  ...
  fullAttributes={ true }
  onSuccess={(signedFiles) => {
    console.log(signedFiles)
  }}
  ...
/>     
```
will log out the full payload returned by the rails active storage endpoint as:
```
[
  {
    id: 183,
    key: "L3kN4RRdsCFFQuiDwd82J39Z",
    filename: "DJI_0058.JPG",
    content_type: "image/jpeg",
    metadata: {}, 
    signed_id: "eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBBYmM9IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--f33fda912f4b4baa72c405efb385352dcf11ad92"
  }
]
```

### Rationale
I understand that often times the `signedId` is all you need to make an attachment. It is sufficient for most cases. However when multiple files are uploaded, the exact file plus other data data is often needed to create or update records. In this case knowing which particular file the resulting AS upload result refers to is impossible with just the `signedId` and extra contextual information is necessary. By returning the entire payload of the newly created `ActiveStorage::Blob` record, the library user can tie the upload results to specific files.

Obviously this is only an issue when multiple files are uploaded and the attachments are not being made all to the same object, but that happens to just the problem I personally have ;).