### PR TITLE
Don't catch user's runtime exceptions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,11 +64,15 @@ class ActiveStorageProvider extends React.Component<Props> {
   handleSuccess = async (ids: string[]) => {
     if (ids.length === 0) return
 
+    let data
     try {
-      const data = await this._hitEndpointWithSignedIds(ids)
-      this.props.onSubmit(data)
+      data = await this._hitEndpointWithSignedIds(ids)
     } catch (e) {
       this.props.onError && this.props.onError(e)
+    }
+
+    if (data) {
+      this.props.onSubmit(data)
     }
   }
 


### PR DESCRIPTION
The "onSubmit" function is provided by the user. In case of failure, the exception should bubble back to the user's code, instead of being caught in the library, so the user can deal with it.